### PR TITLE
Fix private environment variable issue

### DIFF
--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -1,7 +1,10 @@
 $ErrorActionPreference = 'Stop'
 
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+$FolderOfPackage = Split-Path -Parent $toolsDir
+
 # The installer doesn't remove previous versions, so there could be multiple "installs"
-$InstallDirs = Get-ChildItem $env:ChocolateyPackageFolder | 
+$InstallDirs = Get-ChildItem $FolderOfPackage | 
                   Where-Object {($_.psiscontainer) -and ($_.name -match $env:ChocolateyPackageName)}
 
 # Delete all Start Menu links associated with OpenCrom


### PR DESCRIPTION
For some reason I don't understand, both `$env:ChocolateyPackageFolder` and `$PackageFolder` are (recently) illegal variables in Chocolatey packages.  This was my solution to the dozens of packages in which I used them.